### PR TITLE
use GeoIP MaxMind Database with china ip list

### DIFF
--- a/clashcmd.bat
+++ b/clashcmd.bat
@@ -651,11 +651,8 @@ echo !loc_advanced_geoip_updating!
 echo.
 echo -------------------------------------
 echo.
-curl -kLo GeoLite2-Country.tar.gz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=oeEqpP5QI21N&suffix=tar.gz"
-7za.exe e GeoLite2-Country.tar.gz
-7za e GeoLite2-Country.tar "GeoLite2-Country*\GeoLite2-Country.mmdb" -aoa
+curl -kLo GeoLite2-Country.mmdb "https://cdn.jsdelivr.net/gh/alecthw/mmdb_china_ip_list@release/Country.mmdb"
 del "Country.mmdb" /f /q
-del "GeoLite2-Country.tar*" /f /q
 ren GeoLite2-Country.mmdb Country.mmdb
 echo.
 echo -------------------------------------


### PR DESCRIPTION
https://github.com/alecthw/mmdb_china_ip_list
在MaxMind数据库的基础上，加入了china_ip_list和纯真CN数据库，使得对中国IP匹配得更为友好
使用cdn.jsdelivr.net镜像，避免出现由于github被污染而无法更新的错误